### PR TITLE
[FEAT] Stockfish 엔진 다운로드 자동화

### DIFF
--- a/ascii_chess/ai.py
+++ b/ascii_chess/ai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from dataclasses import dataclass
 from typing import Optional
@@ -38,12 +39,74 @@ class StockfishAI:
         self.set_rating(self._rating)
 
     def _launch_engine(self, executable_path: Optional[str]):
-        candidate = executable_path or shutil.which("stockfish")
-        if not candidate:
-            raise FileNotFoundError(
-                "Unable to locate Stockfish executable. Provide EngineConfig.executable_path or add it to PATH."
-            )
-        return chess.engine.SimpleEngine.popen_uci(candidate)
+        # 1. 사용자 지정 경로가 있으면 우선 사용
+        if executable_path:
+            # 상대 경로인 경우 절대 경로로 변환
+            if not os.path.isabs(executable_path):
+                executable_path = os.path.abspath(executable_path)
+            if os.path.isfile(executable_path):
+                print(f"✓ 사용자 지정 Stockfish 경로 사용: {executable_path}")
+                return chess.engine.SimpleEngine.popen_uci(executable_path)
+            else:
+                print(f"⚠️ 지정된 경로를 찾을 수 없습니다: {executable_path}")
+        
+        # 2. 가능한 Stockfish 경로 목록
+        script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        possible_paths = [
+            # Windows에서 일반적인 경로
+            os.path.join(script_dir, "engines", "stockfish", "stockfish-windows-x86-64-avx2.exe"),
+            os.path.join(script_dir, "engines", "stockfish", "stockfish.exe"),
+            os.path.join(script_dir, "stockfish-windows-x86-64-avx2.exe"),
+            os.path.join(script_dir, "stockfish.exe"),
+            "stockfish-windows-x86-64-avx2.exe",
+            "stockfish.exe"
+        ]
+        
+        # 3. 가능한 경로들 확인
+        for path in possible_paths:
+            try:
+                if os.path.isfile(path):
+                    abs_path = os.path.abspath(path)
+                    print(f"✓ Stockfish를 찾았습니다: {abs_path}")
+                    return chess.engine.SimpleEngine.popen_uci(abs_path)
+            except Exception as e:
+                print(f"⚠️ {path} 확인 중 오류: {e}")
+                continue
+                
+        # 4. 재귀적으로 stockfish로 시작하는 파일 검색
+        search_dirs = [
+            os.path.join(script_dir, "engines"),
+            script_dir
+        ]
+        
+        for search_dir in search_dirs:
+            if os.path.isdir(search_dir):
+                for root, _, files in os.walk(search_dir):
+                    for file in files:
+                        if file.lower().startswith('stockfish') and (file.lower().endswith('.exe') or not file.lower().endswith('.md')):
+                            candidate = os.path.join(root, file)
+                            try:
+                                abs_path = os.path.abspath(candidate)
+                                print(f"✓ Stockfish를 찾았습니다: {abs_path}")
+                                return chess.engine.SimpleEngine.popen_uci(abs_path)
+                            except Exception as e:
+                                print(f"⚠️ {candidate} 실행 중 오류: {e}")
+        
+        # 4. 시스템 PATH에서 찾기 (마지막 시도)
+        path = shutil.which("stockfish")
+        if path:
+            print(f"✓ 시스템 PATH에서 Stockfish를 찾았습니다: {path}")
+            return chess.engine.SimpleEngine.popen_uci(path)
+                
+        # 모든 시도 실패
+        raise FileNotFoundError(
+            "Stockfish 실행 파일을 찾을 수 없습니다.\n"
+            "다음 중 하나를 시도해 보세요:\n"
+            f"1. {os.path.join(script_dir, 'engines')} 폴더에 Stockfish 실행 파일을 배치하거나\n"
+            "2. --engine-path 인자로 정확한 경로를 지정하거나\n"
+            "3. 시스템 PATH에 Stockfish를 추가하세요.\n"
+            "4. 프로그램을 다시 실행하면 자동으로 Stockfish를 다운로드할 수 있습니다."
+        )
 
     @property
     def rating(self) -> int:

--- a/ascii_chess/deps.py
+++ b/ascii_chess/deps.py
@@ -173,15 +173,17 @@ def _download_stockfish() -> Optional[str]:
         binary_name = "stockfish-windows-x86-64-avx2.exe"
     elif system == "darwin":  # macOS
         if "arm" in machine:
-            url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-macos-arm64.tar.gz"
-            binary_name = "stockfish-macos-arm64"
+            # Apple Silicon (M1/M2) Mac
+            url = "https://github.com/official-stockfish/Stockfish/releases/latest/download/stockfish-macos-m1-apple-silicon.tar"
+            binary_name = "stockfish"
         else:
-            url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-macos-x86-64.tar.gz"
-            binary_name = "stockfish-macos-x86-64"
+            # Intel Mac
+            url = "https://github.com/official-stockfish/Stockfish/releases/latest/download/stockfish-macos-x86-64-avx2.tar"
+            binary_name = "stockfish"
     elif system == "linux":
-        # Updated URL to use the correct Linux binary from the releases page
-        url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-ubuntu-x86-64.tar.xz"
-        binary_name = "stockfish-ubuntu-x86-64"
+        # Linux with AVX2 support
+        url = "https://github.com/official-stockfish/Stockfish/releases/latest/download/stockfish-ubuntu-x86-64-avx2.tar"
+        binary_name = "stockfish"
     else:
         return None
     

--- a/ascii_chess/deps.py
+++ b/ascii_chess/deps.py
@@ -179,7 +179,8 @@ def _download_stockfish() -> Optional[str]:
             url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-macos-x86-64.tar.gz"
             binary_name = "stockfish-macos-x86-64"
     elif system == "linux":
-        url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-ubuntu-x86-64.tar.gz"
+        # Updated URL to use the correct Linux binary from the releases page
+        url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-ubuntu-x86-64.tar.xz"
         binary_name = "stockfish-ubuntu-x86-64"
     else:
         return None
@@ -212,22 +213,21 @@ def _download_stockfish() -> Optional[str]:
         print("\n압축 해제 중...")
         if system == 'windows':
             with zipfile.ZipFile(tmp_path, 'r') as zip_ref:
-                # 압축 파일 내 파일 목록 가져오기
-                file_list = zip_ref.namelist()
-                total_files = len(file_list)
-                for i, file in enumerate(file_list, 1):
-                    zip_ref.extract(file, base_dir)
-                    print(f"\r진행률: {i}/{total_files} 파일 처리 중...", end='')
-                print()
+                zip_ref.extractall(base_dir)
         else:
             import tarfile
-            with tarfile.open(tmp_path, 'r:gz') as tar_ref:
+            # Determine the correct mode for tarfile
+            if tmp_path.endswith('.tar.xz'):
+                mode = 'r:xz'
+            else:  # .tar.gz or .tgz
+                mode = 'r:gz'
+                
+            with tarfile.open(tmp_path, mode) as tar_ref:
                 members = tar_ref.getmembers()
                 total_members = len(members)
                 for i, member in enumerate(members, 1):
                     tar_ref.extract(member, base_dir)
                     print(f"\r진행률: {i}/{total_members} 파일 처리 중...", end='')
-                print()
         
         # 압축 해제된 파일 찾기
         # Windows의 경우 압축을 풀면 stockfish/stockfish-windows-x86-64-avx2.exe 구조로 풀릴 수 있음

--- a/ascii_chess/deps.py
+++ b/ascii_chess/deps.py
@@ -56,17 +56,21 @@ def locate_stockfish(explicit_path: Optional[str]) -> Optional[str]:
         resolved = _resolve_candidate(explicit_path)
         if resolved:
             return resolved
-        return None
 
+    # 시스템 PATH에서 찾기
     discovered = shutil.which("stockfish")
     if discovered:
         return discovered
 
+    # 번들된 후보들에서 찾기
     for candidate in _bundled_candidates():
         resolved = _resolve_candidate(candidate)
         if resolved:
             return resolved
-    return None
+    
+    # 아무것도 찾지 못한 경우 다운로드 시도
+    print("\n🔍 Stockfish를 찾을 수 없어 다운로드를 시도합니다...")
+    return _download_stockfish()
 
 
 def _resolve_candidate(path: str) -> Optional[str]:
@@ -103,29 +107,207 @@ def _is_executable(path: str) -> bool:
     return os.access(path, os.X_OK)
 
 
+# tqdm이 설치되어 있지 않으면 설치
+try:
+    # Python 3.4+
+    from importlib import util as importlib_util
+    has_tqdm = importlib_util.find_spec('tqdm') is not None
+except (ImportError, AttributeError):
+    # 이전 버전 호환성을 위한 폴백
+    try:
+        import pkg_resources
+        has_tqdm = pkg_resources.get_distribution('tqdm') is not None
+    except (ImportError, pkg_resources.DistributionNotFound):
+        has_tqdm = False
+
+if not has_tqdm:
+    import subprocess
+    import sys
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "tqdm"])
+        print("✓ tqdm 패키지 설치 완료")
+    except subprocess.CalledProcessError as e:
+        print(f"⚠️ tqdm 설치 실패: {e}")
+
+class ProgressBar:
+    def __init__(self):
+        self.pbar = None
+        
+    def __call__(self, block_num, block_size, total_size):
+        if not self.pbar:
+            from tqdm import tqdm
+            self.pbar = tqdm(
+                total=total_size,
+                unit='iB',
+                unit_scale=True,
+                unit_divisor=1024,
+                ncols=70,
+                bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]'
+            )
+        downloaded = block_num * block_size
+        if downloaded < total_size:
+            self.pbar.update(block_size)
+        else:
+            self.pbar.close()
+
+def _download_stockfish() -> Optional[str]:
+    """GitHub 릴리스에서 Stockfish 다운로드"""
+    import urllib.request
+    import zipfile
+    import tempfile
+    import platform
+    import os
+    import time
+    
+    base_dir = Path(__file__).resolve().parent.parent / "engines"
+    base_dir.mkdir(exist_ok=True)
+    
+    # 시스템에 맞는 파일 선택
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    
+    if system == "windows":
+        if "arm" in machine:
+            return None  # Windows ARM은 지원 안 함
+        url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-windows-x86-64-avx2.zip"
+        binary_name = "stockfish-windows-x86-64-avx2.exe"
+    elif system == "darwin":  # macOS
+        if "arm" in machine:
+            url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-macos-arm64.tar.gz"
+            binary_name = "stockfish-macos-arm64"
+        else:
+            url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-macos-x86-64.tar.gz"
+            binary_name = "stockfish-macos-x86-64"
+    elif system == "linux":
+        url = "https://github.com/official-stockfish/Stockfish/releases/download/sf_17.1/stockfish-ubuntu-x86-64.tar.gz"
+        binary_name = "stockfish-ubuntu-x86-64"
+    else:
+        return None
+    
+    # stockfish 하위 디렉토리 생성
+    stockfish_dir = base_dir / "stockfish"
+    stockfish_dir.mkdir(parents=True, exist_ok=True)
+    
+    # 타겟 경로를 stockfish/stockfish.exe로 설정 (Windows) 또는 stockfish/stockfish (기타 OS)
+    target_name = "stockfish.exe" if system == "windows" else "stockfish"
+    target_path = stockfish_dir / target_name
+    
+    # 이미 파일이 있고 실행 가능하면 그대로 반환
+    if target_path.exists() and os.access(target_path, os.X_OK):
+        return str(target_path)
+    
+    print(f"\n📥 Stockfish 17.1 다운로드 중... ({system} {machine})")
+    
+    try:
+        # 임시 파일로 다운로드
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.zip' if system == 'windows' else '.tar.gz') as tmp_file:
+            tmp_path = tmp_file.name
+        
+        # 파일 다운로드 (진행률 표시 포함)
+        print(f"다운로드: {url}")
+        progress = ProgressBar()
+        urllib.request.urlretrieve(url, tmp_path, reporthook=progress)
+        
+        # 압축 해제 (진행률 표시)
+        print("\n압축 해제 중...")
+        if system == 'windows':
+            with zipfile.ZipFile(tmp_path, 'r') as zip_ref:
+                # 압축 파일 내 파일 목록 가져오기
+                file_list = zip_ref.namelist()
+                total_files = len(file_list)
+                for i, file in enumerate(file_list, 1):
+                    zip_ref.extract(file, base_dir)
+                    print(f"\r진행률: {i}/{total_files} 파일 처리 중...", end='')
+                print()
+        else:
+            import tarfile
+            with tarfile.open(tmp_path, 'r:gz') as tar_ref:
+                members = tar_ref.getmembers()
+                total_members = len(members)
+                for i, member in enumerate(members, 1):
+                    tar_ref.extract(member, base_dir)
+                    print(f"\r진행률: {i}/{total_members} 파일 처리 중...", end='')
+                print()
+        
+        # 압축 해제된 파일 찾기
+        # Windows의 경우 압축을 풀면 stockfish/stockfish-windows-x86-64-avx2.exe 구조로 풀릴 수 있음
+        possible_paths = [
+            base_dir / "stockfish" / f"stockfish-{machine}.exe",
+            base_dir / f"stockfish-{machine}.exe",
+            base_dir / binary_name,
+            base_dir / "stockfish" / binary_name
+        ]
+        
+        # 가능한 경로 중 존재하는 파일 찾기
+        downloaded_path = None
+        for path in possible_paths:
+            if path.exists():
+                downloaded_path = path
+                break
+        
+        if downloaded_path is None:
+            # stockfish로 시작하는 파일이 있는지 재검색
+            for f in base_dir.glob("**/stockfish*"):
+                if f.is_file() and (f.suffix == '.exe' or 'stockfish' in f.name.lower()):
+                    downloaded_path = f
+                    break
+        
+        if downloaded_path is None or not downloaded_path.exists():
+            raise FileNotFoundError(
+                f"다운로드한 Stockfish 파일을 찾을 수 없습니다. 다음 위치에서 찾았습니다:\n" +
+                "\n".join(f"- {p}" for p in possible_paths)
+            )
+        
+        # 최종 경로 설정 (stockfish/stockfish.exe)
+        final_path = stockfish_dir / "stockfish.exe"
+        
+        # 기존 파일이 있으면 삭제
+        if final_path.exists():
+            try:
+                final_path.unlink()
+            except Exception as e:
+                print(f"⚠️ 기존 파일 삭제 중 오류: {e}")
+        
+        # stockfish 디렉토리 생성
+        stockfish_dir.mkdir(parents=True, exist_ok=True)
+        
+        # 파일 이동 및 권한 설정
+        shutil.move(str(downloaded_path), str(final_path))
+        if system != 'windows':
+            final_path.chmod(0o755)
+        
+        print(f"✅ Stockfish가 성공적으로 설치되었습니다: {final_path}")
+        return str(final_path)
+        
+    except Exception as e:
+        print(f"❌ 다운로드 실패: {e}")
+        return None
+    finally:
+        # 임시 파일 정리
+        if 'tmp_path' in locals() and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
 def _bundled_candidates() -> list[str]:
     base_dir = Path(__file__).resolve().parent.parent / "engines"
     if not base_dir.exists():
+        # 엔진 디렉토리가 없으면 다운로드 시도
+        downloaded = _download_stockfish()
+        if downloaded:
+            return [downloaded]
         return []
 
     candidates: list[str] = []
-    stockfish_dir = base_dir / "stockfish"
-    if stockfish_dir.exists():
-        candidates.append(str(stockfish_dir))
-
     for entry in sorted(base_dir.iterdir()):
-        if entry.name == "stockfish":
-            continue
         if "stockfish" in entry.name.lower():
             candidates.append(str(entry))
-
-    seen: set[str] = set()
-    result: list[str] = []
-    for candidate in candidates:
-        if candidate not in seen:
-            result.append(candidate)
-            seen.add(candidate)
-    return result
+    
+    # 후보가 없으면 다운로드 시도
+    if not candidates:
+        downloaded = _download_stockfish()
+        if downloaded:
+            return [downloaded]
+    
+    return candidates
 
 
 # ===== 종합 결과 =====

--- a/main.py
+++ b/main.py
@@ -1,29 +1,5 @@
 from __future__ import annotations
 import platform
-
-def is_admin():
-    """Check if the script is running with administrator privileges (Windows only)"""
-    if platform.system() != "Windows":
-        return True  # macOS/Linux에서는 항상 True 반환
-    try:
-        import ctypes
-        return ctypes.windll.shell32.IsUserAnAdmin()
-    except:
-        return False
-
-# Windows에서만 관리자 권한 확인 및 요청
-if platform.system() == "Windows" and not is_admin():
-    import sys
-    import ctypes
-    
-    # 현재 스크립트의 절대 경로 가져오기
-    import os
-    script = os.path.abspath(sys.argv[0])
-    
-    print("폰트 설치를 위해 관리자 권한이 필요합니다. 권한을 요청합니다...")
-    ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, f'"{script}"', None, 1)
-    sys.exit(0)
-
 import argparse
 import os
 import platform
@@ -31,6 +7,17 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+def is_admin():
+    """Check if the script is running with administrator privileges (Windows only)"""
+    if platform.system() != "Windows":
+        return True
+    try:
+        import ctypes
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception as e:
+        print(f"관리자 권한 확인 중 오류: {e}")
+        return False
 
 def check_and_install_package(package_name):
     # python-chess의 실제 임포트 이름은 'chess'이므로 처리
@@ -52,9 +39,45 @@ def check_and_install_package(package_name):
             print(f"✗ {package_name} 패키지 설치 실패: {e}")
             return False
 
+def is_font_installed(font_name="menlo-regular.ttf"):
+    """Check if the specified font is already installed"""
+    if platform.system() != "Windows":
+        return True  # Non-Windows systems are assumed to have the font
+        
+    try:
+        import winreg
+        # Check Windows Fonts directory
+        font_dir = os.path.join(os.environ['WINDIR'], 'Fonts')
+        if os.path.exists(os.path.join(font_dir, font_name)):
+            # Check Windows registry
+            try:
+                key = winreg.OpenKey(
+                    winreg.HKEY_LOCAL_MACHINE,
+                    r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts',
+                    0, winreg.KEY_READ
+                )
+                try:
+                    # Try to find the font in the registry
+                    for i in range(winreg.QueryInfoKey(key)[1]):
+                        name, value, _ = winreg.EnumValue(key, i)
+                        if font_name.lower() in value.lower():
+                            return True
+                finally:
+                    winreg.CloseKey(key)
+            except WindowsError:
+                pass
+    except Exception as e:
+        print(f"⚠️ 폰트 확인 중 오류: {e}")
+    return False
+
 def install_font():
     if platform.system() == "Windows":
         font_name = "menlo-regular.ttf"
+        # Check if font is already installed
+        if is_font_installed(font_name):
+            print(f"✓ {font_name} 폰트가 이미 설치되어 있습니다.")
+            return True
+            
         # 폰트 경로 확인
         font_path = os.path.join("ascii_chess", "fonts", font_name)
         if not os.path.exists(font_path):
@@ -71,31 +94,38 @@ def install_font():
             font_dir = os.path.join(os.environ['WINDIR'], 'Fonts')
             target_path = os.path.join(font_dir, font_name)
             
-            if os.path.exists(target_path):
-                print(f"✓ {font_name} 폰트가 이미 설치되어 있습니다.")
+            # 관리자 권한이 없으면 시도조차 하지 않음
+            if not is_admin():
+                print(f"⚠️ {font_name} 폰트 설치를 위해 관리자 권한이 필요합니다.")
+                return False
+                
+            # 폰트 복사
+            try:
+                shutil.copy2(font_path, font_dir)
+                
+                # 폰트 등록
+                if not ctypes.windll.gdi32.AddFontResourceW(target_path):
+                    print("✗ 폰트 등록에 실패했습니다.")
+                    return False
+                    
+                ctypes.windll.user32.SendMessageW(0xFFFF, 0x001D, 0, 0)
+                
+                # 레지스트리에 등록
+                try:
+                    key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, 
+                                         r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts')
+                    winreg.SetValueEx(key, font_name, 0, winreg.REG_SZ, font_name)
+                    winreg.CloseKey(key)
+                except WindowsError as e:
+                    print(f"✗ 레지스트리 등록 실패: {e}")
+                    return False
+                    
+                print(f"✓ {font_name} 폰트가 성공적으로 설치되었습니다.")
                 return True
                 
-            shutil.copy2(font_path, font_dir)
-            
-            # 폰트 등록
-            if not ctypes.windll.gdi32.AddFontResourceW(target_path):
-                print("✗ 폰트 등록에 실패했습니다.")
+            except Exception as e:
+                print(f"✗ 폰트 설치 중 오류 발생: {e}")
                 return False
-                
-            ctypes.windll.user32.SendMessageW(0xFFFF, 0x001D, 0, 0)
-            
-            # 레지스트리에 등록
-            try:
-                key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, 
-                                     r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts')
-                winreg.SetValueEx(key, font_name, 0, winreg.REG_SZ, font_name)
-                winreg.CloseKey(key)
-            except WindowsError as e:
-                print(f"✗ 레지스트리 등록 실패: {e}")
-                return False
-                
-            print(f"✓ {font_name} 폰트가 성공적으로 설치되었습니다.")
-            return True
             
         except Exception as e:
             print(f"✗ 폰트 설치 중 오류 발생: {e}")
@@ -109,20 +139,6 @@ def install_font():
         print(f"✗ {platform.system()} 시스템은 자동 설치를 지원하지 않습니다.")
         return False
 
-# 필요한 패키지 설치
-if not check_and_install_package("python-chess"):
-    print("\n필수 패키지 설치에 실패하여 프로그램을 실행할 수 없습니다.")
-    if platform.system() == "Windows":
-        input("계속하려면 엔터 키를 누르세요...")
-    sys.exit(1)
-
-# 폰트 설치 시도 (실패해도 프로그램은 계속 실행)
-print("\n필요한 폰트를 확인 중입니다...")
-install_font()
-
-from ascii_chess.deps import collect_dependency_status
-
-
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="ASCII Chess GUI vs Stockfish")
     parser.add_argument("--engine-path", default=None, help="Path to Stockfish executable.")
@@ -131,53 +147,132 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--think-time", type=float, default=0.5, help="Default think time per AI move.")
     parser.add_argument("--ascii-only", action="store_true", help="Use ASCII pieces instead of Unicode.")
     parser.add_argument("--no-auto-install", action="store_true", help="Skip python-chess auto-installation.")
+    parser.add_argument("--skip-fonts", action="store_true", help="Skip font installation.")
+    parser.add_argument("--skip-stockfish", action="store_true", help=argparse.SUPPRESS)  # 내부용
     return parser.parse_args(argv)
 
-
 def main(argv: list[str] | None = None) -> int:
+    # 스크립트 디렉토리로 작업 디렉토리 변경 (관리자 모드에서도 올바른 경로 유지)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(script_dir)
+    
     args = parse_args(argv or sys.argv[1:])
 
-    deps = collect_dependency_status(
-        engine_path=args.engine_path,
-        auto_install=not args.no_auto_install,
-    )
-
-    if not deps.python_chess_ok:
-        print(
-            "python-chess could not be imported. Install it manually with `pip install python-chess` and re-run.",
-            file=sys.stderr,
-        )
+    print("\n🔍 프로그램 초기화 중...")
+    
+    # 필요한 패키지 설치
+    if not check_and_install_package("python-chess"):
+        print("\n❌ python-chess 패키지 설치에 실패했습니다.")
+        if platform.system() == "Windows":
+            input("계속하려면 엔터 키를 누르세요...")
         return 1
 
-    if deps.stockfish_path is None:
-        hint = (
-            "Stockfish executable not found. Download it from https://stockfishchess.org/download/ "
-            "and provide the path with --engine-path /path/to/stockfish."
-        )
-        print(hint, file=sys.stderr)
-        return 1
+    # Stockfish 확인 (관리자 권한 없이도 가능)
+    stockfish_path = None # Initialize stockfish_path
+    if not args.skip_stockfish:
+        print("\n♟️ Chess Engine을 확인 중입니다...")
+        from ascii_chess.deps import collect_dependency_status, _download_stockfish
+        
+        try:
+            # Stockfish 경로 확인
+            if args.engine_path:
+                stockfish_path = args.engine_path
+            else:
+                # engines/stockfish/stockfish.exe 또는 engines/stockfish.exe 경로 확인
+                possible_paths = [
+                    os.path.join("engines", "stockfish", "stockfish.exe"),
+                    os.path.join("engines", "stockfish.exe"),
+                    "stockfish.exe"
+                ]
+                
+                for path in possible_paths:
+                    if os.path.exists(path):
+                        stockfish_path = os.path.abspath(path)
+                        break
+                
+                # 찾지 못한 경우 다운로드 시도
+                if not stockfish_path:
+                    print("Stockfish를 찾을 수 없어 다운로드를 시도합니다...")
+                    stockfish_path = _download_stockfish()
+            
+            if not stockfish_path or not os.path.exists(stockfish_path):
+                print("\n❌ Chess Engine을 찾을 수 없습니다.")
+                if platform.system() == "Windows":
+                    input("계속하려면 엔터 키를 누르세요...")
+                return 1
+                
+            print(f"✓ Chess Engine이 준비되었습니다: {stockfish_path}")
+        except Exception as e:
+            print(f"\n⚠️ Chess Engine 확인 중 오류 발생: {e}")
+            if platform.system() == "Windows":
+                input("계속하려면 엔터 키를 누르세요...")
+            return 1
 
+    # 폰트 설치 (관리자 권한 필요)
+    if not args.skip_fonts and platform.system() == "Windows":
+        print("\n🔄 필요한 폰트를 확인 중입니다...")
+        try:
+            if is_font_installed():
+                print("✓ 필요한 폰트가 이미 설치되어 있습니다.")
+            elif is_admin():
+                # 관리자 모드로 실행된 경우
+                install_font()
+            else:
+                print("\n⚠️ 폰트 설치를 위해 관리자 권한이 필요합니다.")
+                print("관리자 권한으로 다시 실행하시겠습니까? (Y/N): ", end='')
+                if input().strip().lower() == 'y':
+                    import ctypes
+                    script = os.path.abspath(__file__)
+                    params = ' '.join(['--skip-stockfish'] + [arg for arg in sys.argv[1:] if arg != '--skip-stockfish'])
+                    print(f"\n관리자 권한으로 다시 실행합니다...")
+                    result = ctypes.windll.shell32.ShellExecuteW(
+                        None, "runas", sys.executable, f'"{script}" {params}', None, 1
+                    )
+                    if result <= 32:  # ShellExecute 실패 시
+                        print("⚠️ 관리자 권한을 얻지 못했습니다. 기본 폰트로 계속 진행합니다.")
+                    else:
+                        return 0  # 관리자 권한으로 새 프로세스가 시작되므로 종료
+                else:
+                    print("⚠️ 기본 폰트로 계속 진행합니다.")
+        except Exception as e:
+            print(f"⚠️ 폰트 확인/설치 중 오류 발생: {e}")
+            print("⚠️ 기본 폰트로 계속 진행합니다.")
+
+    # GUI 실행
     try:
         import tkinter as tk
-    except Exception as exc:
-        print(f"Failed to load Tkinter: {exc}", file=sys.stderr)
+        from ascii_chess.ai import EngineConfig
+        from ascii_chess.gui import ChessGUI
+
+        print("\n🚀 체스 게임을 시작합니다...")
+        
+        engine_config = EngineConfig(
+            executable_path=stockfish_path,
+            min_rating=args.min_rating,
+            max_rating=args.max_rating,
+            default_think_time=args.think_time,
+        )
+
+        root = tk.Tk()
+        ChessGUI(root, engine_config=engine_config, use_unicode=not args.ascii_only)
+        root.mainloop()
+        return 0
+        
+    except Exception as e:
+        print(f"\n❌ GUI 실행 중 오류가 발생했습니다: {e}")
+        import traceback
+        traceback.print_exc()
+        if platform.system() == "Windows":
+            input("\n계속하려면 엔터 키를 누르세요...")
         return 1
 
-    from ascii_chess.ai import EngineConfig
-    from ascii_chess.gui import ChessGUI
-
-    engine_config = EngineConfig(
-        executable_path=deps.stockfish_path,
-        min_rating=args.min_rating,
-        max_rating=args.max_rating,
-        default_think_time=args.think_time,
-    )
-
-    root = tk.Tk()
-    ChessGUI(root, engine_config=engine_config, use_unicode=not args.ascii_only)
-    root.mainloop()
-    return 0
-
-
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"\n❌ 치명적 오류가 발생했습니다: {e}")
+        import traceback
+        traceback.print_exc()
+        if platform.system() == "Windows":
+            input("\n계속하려면 엔터 키를 누르세요...")
+        sys.exit(1)


### PR DESCRIPTION
Before
- 사용자가 직접 사이트에서 다운 받아 압축 해제 후 engine/ 폴더로 옮겨야 했음

After
- python main.py 실행시 기존 python-chess 다운 및 폰트와 함께 Stockfish 엔진도 다운로드함
- 만약 Stockfish가 이미 있다면 스킵
- tqdm 모듈을 임포트하여 다운로드 현황을 시각화 함

참고사항
- 맥 환경에선 테스트 필요함
- 윈도우 환경에서는 되는 것을 확인함